### PR TITLE
feat: update ltsvparser to v0.2.8 and refactor parsing functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ check:
 
 lint:
 	golangci-lint run --timeout 5m ./...
+
+bench:
+	go test -bench BenchmarkParse -benchmem -run '^$$' .

--- a/axslog/axslog.go
+++ b/axslog/axslog.go
@@ -59,9 +59,17 @@ func NewStats() *Stats {
 	}
 }
 
-// GetTotal :
-func (s *Stats) GetTotal() float64 {
-	return s.total
+// Dump status for debug/test
+func (s *Stats) Dump() map[string]float64 {
+	return map[string]float64{
+		"c1xx":  s.c1xx,
+		"c2xx":  s.c2xx,
+		"c3xx":  s.c3xx,
+		"c4xx":  s.c4xx,
+		"c499":  s.c499,
+		"c5xx":  s.c5xx,
+		"total": s.total,
+	}
 }
 
 // Append :

--- a/axslog/axslog.go
+++ b/axslog/axslog.go
@@ -3,9 +3,7 @@ package axslog
 import (
 	"bytes"
 	"fmt"
-	"strconv"
 	"time"
-	"unsafe"
 
 	"github.com/montanaflynn/stats"
 )
@@ -44,7 +42,7 @@ type StatsCh struct {
 	Err     error
 }
 
-func statusCode(status int) int {
+func statusCode(status int64) int64 {
 	switch status {
 	case 499:
 		return 499
@@ -67,7 +65,7 @@ func (s *Stats) GetTotal() float64 {
 }
 
 // Append :
-func (s *Stats) Append(ptime float64, status int) {
+func (s *Stats) Append(ptime float64, status int64) {
 	switch statusCode(status) {
 	case 2:
 		s.c2xx++
@@ -126,16 +124,6 @@ func (s *Stats) Display(keyPrefix string) string {
 		fmt.Fprintf(&buf, "axslog.access_ratio_%s.5xx_percentage\t%f\t%d\n", keyPrefix, s.c5xx*100/s.total, now)
 	}
 	return buf.String()
-}
-
-// BFloat64 :
-func BFloat64(b []byte) (float64, error) {
-	return strconv.ParseFloat(unsafe.String(unsafe.SliceData(b), len(b)), 64)
-}
-
-// BInt :
-func BInt(b []byte) (int, error) {
-	return strconv.Atoi(unsafe.String(unsafe.SliceData(b), len(b)))
 }
 
 // DisplayAll :

--- a/axslog/axslog_test.go
+++ b/axslog/axslog_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestStatusCode(t *testing.T) {
 	tests := []struct {
-		status   int
-		expected int
+		status   int64
+		expected int64
 	}{
 		{200, 2},
 		{301, 3},
@@ -56,40 +56,6 @@ func TestStatsSetDuration(t *testing.T) {
 	s.SetDuration(60.0)
 	if s.duration != 60.0 {
 		t.Errorf("duration = %f; want 60.0", s.duration)
-	}
-}
-
-func TestBFloat64(t *testing.T) {
-	v, err := BFloat64([]byte("3.14"))
-	if err != nil {
-		t.Fatalf("BFloat64 error: %v", err)
-	}
-	if v != 3.14 {
-		t.Errorf("BFloat64 = %f; want 3.14", v)
-	}
-}
-
-func TestBFloat64Invalid(t *testing.T) {
-	_, err := BFloat64([]byte("not-a-number"))
-	if err == nil {
-		t.Error("BFloat64 should return error for invalid input")
-	}
-}
-
-func TestBInt(t *testing.T) {
-	v, err := BInt([]byte("200"))
-	if err != nil {
-		t.Fatalf("BInt error: %v", err)
-	}
-	if v != 200 {
-		t.Errorf("BInt = %d; want 200", v)
-	}
-}
-
-func TestBIntInvalid(t *testing.T) {
-	_, err := BInt([]byte("abc"))
-	if err == nil {
-		t.Error("BInt should return error for invalid input")
 	}
 }
 

--- a/axslog/axslog_test.go
+++ b/axslog/axslog_test.go
@@ -34,7 +34,7 @@ func TestNewStats(t *testing.T) {
 	require.Equal(t, 0, len(s.f64s), "f64s length = %d; want 0", len(s.f64s))
 }
 
-func TestStatsAppendAndGetTotal(t *testing.T) {
+func TestStatsAppendAndTotal(t *testing.T) {
 	s := NewStats()
 	s.Append(0.010, 200)
 	s.Append(0.020, 200)
@@ -42,12 +42,11 @@ func TestStatsAppendAndGetTotal(t *testing.T) {
 	s.Append(0.040, 499)
 	s.Append(0.050, 500)
 
-	total := s.GetTotal()
-	assert.Equal(t, 5.0, total, "GetTotal() = %f; want 5", total)
-	assert.Equal(t, 2.0, s.c2xx, "c2xx = %f; want 2", s.c2xx)
-	assert.Equal(t, 1.0, s.c4xx, "c4xx = %f; want 1", s.c4xx)
-	assert.Equal(t, 1.0, s.c499, "c499 = %f; want 1", s.c499)
-	assert.Equal(t, 1.0, s.c5xx, "c5xx = %f; want 1", s.c5xx)
+	assert.Equal(t, 5.0, s.total, "Total = %f; want 5", s.total)
+	assert.Equal(t, 2.0, s.c2xx, "C2xx = %f; want 2", s.c2xx)
+	assert.Equal(t, 1.0, s.c4xx, "C4xx = %f; want 1", s.c4xx)
+	assert.Equal(t, 1.0, s.c499, "C499 = %f; want 1", s.c499)
+	assert.Equal(t, 1.0, s.c5xx, "C5xx = %f; want 1", s.c5xx)
 	assert.Equal(t, 5, len(s.f64s), "len(f64s) = %d; want 5", len(s.f64s))
 }
 
@@ -55,7 +54,7 @@ func TestStatsSetDuration(t *testing.T) {
 	s := NewStats()
 	s.SetDuration(60.0)
 	if s.duration != 60.0 {
-		t.Errorf("duration = %f; want 60.0", s.duration)
+		t.Errorf("Duration = %f; want 60.0", s.duration)
 	}
 }
 
@@ -127,13 +126,13 @@ func TestStatsAppendAllStatusClasses(t *testing.T) {
 	s.Append(0.005, 499)
 	s.Append(0.006, 503)
 
-	assert.Equal(t, 6.0, s.total, "total = %f; want 6", s.total)
-	assert.Equal(t, 1.0, s.c1xx, "c1xx = %f; want 1", s.c1xx)
-	assert.Equal(t, 1.0, s.c2xx, "c2xx = %f; want 1", s.c2xx)
-	assert.Equal(t, 1.0, s.c3xx, "c3xx = %f; want 1", s.c3xx)
-	assert.Equal(t, 1.0, s.c4xx, "c4xx = %f; want 1", s.c4xx)
-	assert.Equal(t, 1.0, s.c499, "c499 = %f; want 1", s.c499)
-	assert.Equal(t, 1.0, s.c5xx, "c5xx = %f; want 1", s.c5xx)
+	assert.Equal(t, 6.0, s.total, "Total = %f; want 6", s.total)
+	assert.Equal(t, 1.0, s.c1xx, "C1xx = %f; want 1", s.c1xx)
+	assert.Equal(t, 1.0, s.c2xx, "C2xx = %f; want 1", s.c2xx)
+	assert.Equal(t, 1.0, s.c3xx, "C3xx = %f; want 1", s.c3xx)
+	assert.Equal(t, 1.0, s.c4xx, "C4xx = %f; want 1", s.c4xx)
+	assert.Equal(t, 1.0, s.c499, "C499 = %f; want 1", s.c499)
+	assert.Equal(t, 1.0, s.c5xx, "C5xx = %f; want 1", s.c5xx)
 }
 
 func TestDisplayAllAggregatedPercentages(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/monitoring-forge/flagrun v0.0.8
 	github.com/monitoring-forge/followparser v0.2.15
-	github.com/monitoring-forge/ltsvparser v0.2.7
+	github.com/monitoring-forge/ltsvparser v0.2.8
 	github.com/montanaflynn/stats v0.12.4
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/monitoring-forge/flagrun v0.0.8 h1:CEoMMdFpZ4KOTiBy2mAUQtlgFsTqpvpEoL
 github.com/monitoring-forge/flagrun v0.0.8/go.mod h1:yAwxGIEx81wU4JOMp6hz7SdSYWgT/Hr4JXEdHlEn1mw=
 github.com/monitoring-forge/followparser v0.2.15 h1:JiCtehe8NVd8BdfuLFzM9EDoVO3Ya4g3lunhJpnZk7k=
 github.com/monitoring-forge/followparser v0.2.15/go.mod h1:L3I8hiQxz9ahjz/pPxCVfjBYHTejwKeR7XaG9TYglyY=
-github.com/monitoring-forge/ltsvparser v0.2.7 h1:6FFnXzhJgU3LRsJ0z4bNbEtJEK+Xo9zAyIIFZK8X8uI=
-github.com/monitoring-forge/ltsvparser v0.2.7/go.mod h1:kbNExT98jYMhQE5wphmq2avnuxEorZL/CfDKIUuyimE=
+github.com/monitoring-forge/ltsvparser v0.2.8 h1:eb/lY5zFsw7RYcI8H0bZP3Jm9d9MrxRyIuwXAZlgyGk=
+github.com/monitoring-forge/ltsvparser v0.2.8/go.mod h1:kbNExT98jYMhQE5wphmq2avnuxEorZL/CfDKIUuyimE=
 github.com/montanaflynn/stats v0.12.4 h1:amtNRsti20yIhcrkfUJGwoYqBR82jKQFE8SNNYVgGn0=
 github.com/montanaflynn/stats v0.12.4/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=

--- a/parser.go
+++ b/parser.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"log"
 
+	"github.com/buger/jsonparser"
+	"github.com/monitoring-forge/ltsvparser"
 	"github.com/monitoring-forge/mackerel-plugin-axslog/axslog"
 	"github.com/monitoring-forge/mackerel-plugin-axslog/jsonreader"
 	"github.com/monitoring-forge/mackerel-plugin-axslog/ltsvreader"
@@ -65,12 +67,12 @@ func (p *parser) Parse(b []byte) error {
 		log.Printf("No status. continue key:%v", p.opt.StatusKeys)
 		return nil
 	}
-	ptime, err := axslog.BFloat64(pt)
+	ptime, err := ltsvparser.ParseFloat(pt)
 	if err != nil {
 		log.Printf("Failed to convert ptime. continue: %v", err)
 		return nil
 	}
-	status, err := axslog.BInt(st)
+	status, err := jsonparser.ParseInt(st)
 	if err != nil {
 		log.Printf("Failed to convert status. continue: %v", err)
 		return nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -44,9 +44,9 @@ func BenchmarkParse_LTSVParse(b *testing.B) {
 	p := opt.NewParser(stats)
 
 	data := []byte("time:08/Mar/2017:14:12:40 +0900	status:200	ptime:0.030	host:10.20.30.40	req:GET /example/path HTTP/1.1	method:GET	size:941	ua:Mozilla/5.0 (Linux; Android 4.4.2; SO-01F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36")
-	b.ResetTimer()
+
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		_ = p.Parse(data)
 	}
 }
@@ -62,9 +62,9 @@ func BenchmarkParse_JSONParse(b *testing.B) {
 	p := opt.NewParser(stats)
 
 	data := []byte(`{"time":"08/Mar/2017:14:12:40 +0900","status":"200","ptime":"0.030","host":"10.20.30.40","req":"GET /example/path HTTP/1.1","method":"GET","size":"941","ua":"Mozilla/5.0 (Linux; Android 4.4.2; SO-01F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36"}`)
-	b.ResetTimer()
+
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		_ = p.Parse(data)
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -33,6 +33,30 @@ func TestFiltered(t *testing.T) {
 	}
 }
 
+func TestParse(t *testing.T) {
+	opt := &Opt{
+		Format:     "ltsv",
+		PtimeKey:   "ptime",
+		StatusKeys: []string{"status"},
+	}
+	stats := axslog.NewStats()
+	p := opt.NewParser(stats)
+
+	input := []byte("time:08/Mar/2017:14:12:40 +0900	status:200	ptime:0.030	host:10.20.30.40	req:GET /example/path HTTP/1.1	method:GET	size:941	ua:Mozilla/5.0 (Linux; Android 4.4.2; SO-01F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36")
+	err := p.Parse(input)
+	if err != nil {
+		t.Errorf("Parse() returned an error: %v", err)
+	}
+
+	dump := stats.Dump()
+	if dump["total"] != 1.0 {
+		t.Errorf("Total = %f; want 1.0", dump["total"])
+	}
+	if dump["c2xx"] != 1.0 {
+		t.Errorf("C2xx = %f; want 1.0", dump["c2xx"])
+	}
+}
+
 func BenchmarkParse_LTSVParse(b *testing.B) {
 	opt := &Opt{
 		Format:     "ltsv",


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Use optimized external numeric parsers.

- Upgrade `ltsvparser` to `v0.2.8`.

- Add inspectable statistics dump and parsing coverage.

- Add benchmark Makefile target.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Input["LTSV or JSON log fields"]
  Parsers["External numeric parsers"]
  Stats["Stats aggregation and Dump"]
  Input -- "parse ptime and status" --> Parsers
  Parsers -- "append parsed values" --> Stats
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>axslog.go</strong><dd><code>Modernize status types and statistics diagnostics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

axslog/axslog.go

<ul><li>Change status handling from <code>int</code> to <code>int64</code>.<br> <li> Add <code>Stats.Dump</code> for exposing counters and totals.<br> <li> Remove local unsafe byte-to-number conversion helpers.</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/mackerel-plugin-axslog/pull/90/files#diff-3fd21782be5e5e200356c3698e58615bb47e9143bda9d8b9b4d6ce3421018fb9">+13/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser.go</strong><dd><code>Delegate numeric parsing to external libraries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

parser.go

<ul><li>Parse response times with <code>ltsvparser.ParseFloat</code>.<br> <li> Parse status values with <code>jsonparser.ParseInt</code>.<br> <li> Remove dependency on deleted <code>axslog</code> conversion helpers.</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/mackerel-plugin-axslog/pull/90/files#diff-83eb8e32639d01cf443d6d8bde24c1c8be78766090d8c5f8586c36250cfedca6">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Add parser benchmark Makefile target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Add <code>bench</code> target for parser benchmark execution.<br> <li> Report benchmark memory allocations without running tests.</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/mackerel-plugin-axslog/pull/90/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>axslog_test.go</strong><dd><code>Align stats tests with API changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

axslog/axslog_test.go

<ul><li>Update status-code tests for <code>int64</code> inputs.<br> <li> Test totals through stats fields instead of <code>GetTotal</code>.<br> <li> Remove tests for deleted numeric conversion helpers.<br> <li> Standardize assertion messages for counter fields.</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/mackerel-plugin-axslog/pull/90/files#diff-499a2349270d4dac8dc3b8b88d85611fa4e38f68790b1e908e347d16cc0f92c3">+16/-51</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser_test.go</strong><dd><code>Test parser statistics and modernize benchmarks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

parser_test.go

<ul><li>Add LTSV parsing coverage for total and <code>2xx</code> counters.<br> <li> Update benchmarks to use <code>b.Loop</code>.<br> <li> Preserve allocation reporting for parser benchmarks.</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/mackerel-plugin-axslog/pull/90/files#diff-eff279f70f1a81e2abdae4e57736a72120ce3a184bc25ccdbbb60cb10b3027c5">+28/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Upgrade ltsvparser dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

- Upgrade `github.com/monitoring-forge/ltsvparser` to `v0.2.8`.


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/mackerel-plugin-axslog/pull/90/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

