### PR TITLE
feat: ベンチマークテストの追加とオプションの更新

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,4 @@ lint:
 
 bench:
 	go test -bench BenchmarkParse -benchmem -run '^$$' .
+	go test -bench BenchmarkMainParse -benchmem -run '^$$' .

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ mackerel-plugin-axslog \
 | `--invert-filter` | `--filter` 指定時に、指定文字列を含まない行だけを集計 |
 | `--skip-until-json` | JSON の前にプレーンテキストの接頭辞がある行で、最初の `{` までを無視 |
 | `--max-read-size` | 1 回の実行で読む最大サイズ。`10MB`、`2GiB` のように指定。未指定時は LTSV が 1GB、JSON が 500MB |
+| `-q`, `--quiet` | 解析時のログ出力を抑制 |
 
 ## mackerel-agent での設定
 

--- a/main.go
+++ b/main.go
@@ -51,7 +51,9 @@ type Opt struct {
 	SkipUntilBracket bool       `long:"skip-until-json" description:"skip reading until first { for json log with plain text header"`
 	InvertFilter     bool       `long:"invert-filter" description:"select lines don't contain a specified text from log if a filter is specified"`
 	MaxReadSize      HumanBytes `long:"max-read-size" description:"maximum size of log file to read (e.g. 10MB, 2GiB). 0 uses the default per format"`
+	Quiet            bool       `short:"q" long:"quiet" description:"Suppress output"`
 	Version          bool       `short:"v" long:"version" description:"Show version"`
+	workdir          string
 }
 
 func (opt *Opt) getFileStats(posFile, logFile string) (*axslog.Stats, error) {
@@ -72,11 +74,15 @@ func (opt *Opt) getFileStats(posFile, logFile string) (*axslog.Stats, error) {
 	}
 	maxReadSize := int64(maxReadSizeU)
 
+	if opt.workdir == "" {
+		opt.workdir = pluginutil.PluginWorkDir()
+	}
+
 	parser := opt.NewParser(stats)
 	fp := &followparser.Parser{
-		WorkDir:      pluginutil.PluginWorkDir(),
+		WorkDir:      opt.workdir,
 		Callback:     parser,
-		Silent:       false,
+		Silent:       opt.Quiet,
 		MaxReadSize:  maxReadSize,
 		StartBufSize: StartBufSize,
 		MaxBufSize:   MaxScanTokenSize,

--- a/main_test.go
+++ b/main_test.go
@@ -160,8 +160,8 @@ func benchParser(b *testing.B, dir, filename string, numLines int) {
 		if s == nil {
 			b.Fatal("Stats is nil")
 		}
-		if s.Dump()["total"] != 100000.0 {
-			b.Fatalf("Total = %f; want 100000.0", s.Dump()["total"])
+		if s.Dump()["total"] != float64(numLines) {
+			b.Fatalf("Total = %f; want %f", s.Dump()["total"], float64(numLines))
 		}
 		b.StartTimer()
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,15 @@
 package main
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
 
 func TestHumanBytesUnmarshalFlag(t *testing.T) {
 	var hb HumanBytes
@@ -17,4 +26,156 @@ func TestHumanBytesUnmarshalFlagInvalid(t *testing.T) {
 	if err := hb.UnmarshalFlag("invalid"); err == nil {
 		t.Error("UnmarshalFlag should return error for invalid input")
 	}
+}
+
+func generateJSONLFile(b testing.TB, dir, filename string, numLines int) error {
+	b.Helper()
+	filepath := fmt.Sprintf("%s/%s", dir, filename)
+	file, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	for i := 0; i < numLines; i++ {
+		line := fmt.Sprintf(`{"time": "%s", "status": "%d", "reqtime": "%f", "host": "%s", "req": "%s", "method": "%s", "size": "%d", "ua": "%s"}`,
+			time.Now().Format(time.RFC3339),
+			200+i%5,
+			float64(i)/100.0,
+			"10.20.30.40",
+			"GET /example/path HTTP/1.1",
+			"GET",
+			941,
+			"Mozilla/5.0 (Linux; Android 4.4.2; SO-01F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36",
+		)
+		_, err := file.WriteString(line + "\n")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func generateLTSVFile(b testing.TB, dir, filename string, numLines int) error {
+	b.Helper()
+	filepath := fmt.Sprintf("%s/%s", dir, filename)
+	file, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	for i := 0; i < numLines; i++ {
+		line := fmt.Sprintf("time:%s\tstatus:%d\treqtime:%f\thost:%s\treq:%s\tmethod:%s\tsize:%d\tua:%s",
+			time.Now().Format(time.RFC3339),
+			200+i%5,
+			float64(i)/100.0,
+			"10.20.30.40",
+			"GET /example/path HTTP/1.1",
+			"GET",
+			941,
+			"Mozilla/5.0 (Linux; Android 4.4.2; SO-01F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36",
+		)
+		_, err := file.WriteString(line + "\n")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resetFollowParserStateFile(b testing.TB, dir, filename, posFile string) error {
+	b.Helper()
+	stateFilepath := fmt.Sprintf("%s-%d", posFile, os.Geteuid())
+	stateFile, err := os.Create(filepath.Join(dir, stateFilepath))
+	if err != nil {
+		return err
+	}
+	defer stateFile.Close()
+
+	filepath := fmt.Sprintf("%s/%s", dir, filename)
+	stats, err := os.Stat(filepath)
+	if err != nil {
+		return err
+	}
+	inode := stats.Sys().(*syscall.Stat_t).Ino
+	dev := stats.Sys().(*syscall.Stat_t).Dev
+
+	_, err = stateFile.WriteString(fmt.Sprintf(`{"pos": %d, "time": %f, "inode": %d, "dev": %d}`, 0, float64(time.Now().Unix()-10), inode, dev))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func benchParser(b *testing.B, dir, filename string, numLines int) {
+	b.Helper()
+	format := "json"
+	if strings.HasSuffix(filename, ".ltsv") {
+		format = "ltsv"
+	}
+	opt := &Opt{
+		Format:     format,
+		PtimeKey:   "reqtime",
+		StatusKeys: []string{"status"},
+		Filter:     "",
+		LogFile:    fmt.Sprintf("%s/%s", dir, filename),
+		KeyPrefix:  "test",
+		Quiet:      true,
+		workdir:    dir,
+	}
+
+	if format == "json" {
+		if err := generateJSONLFile(b, dir, filename, numLines); err != nil {
+			b.Fatal(err)
+		}
+	} else if format == "ltsv" {
+		if err := generateLTSVFile(b, dir, filename, numLines); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	curUser, _ := user.Current()
+	uid := "0"
+	if curUser != nil {
+		uid = curUser.Uid
+	}
+	posFile := fmt.Sprintf("%s-axslog-v5-%s", uid, opt.KeyPrefix)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		b.StopTimer()
+		if err := resetFollowParserStateFile(b, dir, filename, posFile); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		s, err := opt.getFileStats(posFile, opt.LogFile)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StopTimer()
+		if s == nil {
+			b.Fatal("Stats is nil")
+		}
+		if s.Dump()["total"] != 100000.0 {
+			b.Fatalf("Total = %f; want 100000.0", s.Dump()["total"])
+		}
+		b.StartTimer()
+	}
+
+	return
+}
+
+// generate 100k JSONL file and parse benchmark
+func BenchmarkMainParse_jsonl(b *testing.B) {
+	tmpDir := b.TempDir()
+	benchParser(b, tmpDir, "test.jsonl", 100000)
+}
+
+func BenchmarkMainParse_ltsv(b *testing.B) {
+	tmpDir := b.TempDir()
+	benchParser(b, tmpDir, "test.ltsv", 100000)
 }


### PR DESCRIPTION
### **User description**
- `Makefile` に `BenchmarkMainParse` のベンチマークテストを追加
- `README.md` に `--quiet` オプションの説明を追加
- `main.go` に `--quiet` オプションを追加し、ログ出力を抑制
- `main_test.go` に JSONL および LTSV のベンチマークテストを追加


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add quiet mode for parser output suppression.

- Reuse a configurable parser working directory.

- Benchmark full JSONL and LTSV parsing.

- Document and run new benchmarks.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Options["CLI options"] 
  Parser["Follow parser"]
  Benchmarks["JSONL and LTSV benchmarks"]
  Options -- "configures quiet mode and workdir" --> Parser
  Benchmarks -- "measures full-file parsing" --> Parser
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Add quiet mode and reusable parser workdir</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.go

<ul><li>Add <code>-q</code> / <code>--quiet</code> option to suppress parser output.<br> <li> Cache the plugin work directory in <code>Opt</code>.<br> <li> Pass configured work directory and quiet mode to <code>followparser.Parser</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/mackerel-plugin-axslog/pull/92/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main_test.go</strong><dd><code>Add full JSONL and LTSV parse benchmarks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main_test.go

<ul><li>Generate temporary 100k-line JSONL and LTSV fixtures.<br> <li> Reset follow-parser position state before each iteration.<br> <li> Benchmark end-to-end parsing with allocation reporting.<br> <li> Verify parsed totals match generated line counts.</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/mackerel-plugin-axslog/pull/92/files#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5e">+162/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Include main parsing benchmarks in bench target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

- Run `BenchmarkMainParse` from the `bench` target.


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/mackerel-plugin-axslog/pull/92/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document quiet output suppression option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

- Document the `-q` and `--quiet` options.


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/mackerel-plugin-axslog/pull/92/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

